### PR TITLE
fix: Remove deprecated `bottle :unneeded`

### DIFF
--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -6,7 +6,6 @@ class GolangciLint < Formula
   desc "Fast linters runner for Go."
   homepage "https://golangci.com"
   version "1.42.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Homebrew emits `Warning: Calling bottle :unneeded is deprecated! There is no 
replacement.`

Since this isn't one of the official taps, this option wasn't needed, and is now
deprecated by Homebrew, so it can safely be removed.