### PR TITLE
fix: deprecation warning

### DIFF
--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -6,7 +6,6 @@ class GolangciLint < Formula
   desc "Fast linters runner for Go."
   homepage "https://golangci.com"
   version "1.42.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
fixes this warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the golangci/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/golangci/homebrew-tap/Formula/golangci-lint.rb:9
```

latest goreleaser versions will generate it correctly...